### PR TITLE
JSR publish用slow types対応 - public APIスキーマに明示的型注釈を追加

### DIFF
--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -49,7 +49,8 @@ export const StartRecordSchema = z.number().int().positive().default(1);
 /**
  * Maximum records parameter
  */
-export const MaximumRecordsSchema = z.number().int().positive().max(500)
+export const MaximumRecordsSchema: z.ZodDefault<z.ZodNumber> = z.number().int()
+  .positive().max(500)
   .default(10);
 
 /**

--- a/src/schemas/opensearch/request.ts
+++ b/src/schemas/opensearch/request.ts
@@ -8,7 +8,10 @@ import { MaximumRecordsSchema } from "../common.ts";
 /**
  * OpenSearch query parameter schema
  */
-export const OpenSearchQuerySchema = z.string().min(1, "Query cannot be empty");
+export const OpenSearchQuerySchema: z.ZodString = z.string().min(
+  1,
+  "Query cannot be empty",
+);
 
 /**
  * OpenSearch count parameter (equivalent to maximumRecords)
@@ -18,7 +21,13 @@ export const OpenSearchCountSchema = MaximumRecordsSchema;
 /**
  * OpenSearch API request parameters schema
  */
-export const OpenSearchRequestSchema = z.object({
+export const OpenSearchRequestSchema: z.ZodType<{
+  q: string;
+  count?: number;
+  start?: number;
+  format?: "rss" | "atom";
+  hl?: "ja" | "en";
+}> = z.object({
   /**
    * Search query string
    */

--- a/src/schemas/sru/query-builder.ts
+++ b/src/schemas/sru/query-builder.ts
@@ -72,7 +72,9 @@ export const NDLSearchFieldSchema = z.enum([
 /**
  * Language codes supported by NDL
  */
-export const NDLLanguageCodeSchema = z.enum([
+export const NDLLanguageCodeSchema: z.ZodType<
+  "jpn" | "eng" | "chi" | "kor" | "fre" | "ger" | "rus" | "spa" | "ita" | "por"
+> = z.enum([
   "jpn", // 日本語
   "eng", // 英語
   "chi", // 中国語
@@ -88,7 +90,20 @@ export const NDLLanguageCodeSchema = z.enum([
 /**
  * Material types in NDL
  */
-export const NDLMaterialTypeSchema = z.enum([
+export const NDLMaterialTypeSchema: z.ZodType<
+  | "Book"
+  | "Article"
+  | "Journal"
+  | "Newspaper"
+  | "Thesis"
+  | "Map"
+  | "Music"
+  | "Video"
+  | "Sound"
+  | "Software"
+  | "Website"
+  | "Database"
+> = z.enum([
   "Book", // 図書
   "Article", // 記事・論文
   "Journal", // 雑誌
@@ -106,7 +121,10 @@ export const NDLMaterialTypeSchema = z.enum([
 /**
  * Date range schema
  */
-export const DateRangeSchema = z.object({
+export const DateRangeSchema: z.ZodType<{
+  from?: string;
+  to?: string;
+}> = z.object({
   /**
    * Start date (YYYY or YYYY-MM-DD format)
    */
@@ -157,7 +175,95 @@ export const SearchFieldSchema = z.object({
  * Simple search parameters schema
  * For common search scenarios with intuitive field names
  */
-export const SimpleSearchParamsSchema = z.object({
+export const SimpleSearchParamsSchema: z.ZodType<{
+  title?: string;
+  creator?: string;
+  subject?: string;
+  publisher?: string;
+  isbn?: string;
+  issn?: string;
+  jpno?: string;
+  language?:
+    | "jpn"
+    | "eng"
+    | "chi"
+    | "kor"
+    | "fre"
+    | "ger"
+    | "rus"
+    | "spa"
+    | "ita"
+    | "por"
+    | (
+      | "jpn"
+      | "eng"
+      | "chi"
+      | "kor"
+      | "fre"
+      | "ger"
+      | "rus"
+      | "spa"
+      | "ita"
+      | "por"
+    )[];
+  dateRange?: { from?: string; to?: string };
+  type?:
+    | "Book"
+    | "Article"
+    | "Journal"
+    | "Newspaper"
+    | "Thesis"
+    | "Map"
+    | "Music"
+    | "Video"
+    | "Sound"
+    | "Software"
+    | "Website"
+    | "Database";
+  anywhere?: string;
+  description?: string;
+  exclude?: {
+    title?: string;
+    creator?: string;
+    subject?: string;
+    language?:
+      | "jpn"
+      | "eng"
+      | "chi"
+      | "kor"
+      | "fre"
+      | "ger"
+      | "rus"
+      | "spa"
+      | "ita"
+      | "por"
+      | (
+        | "jpn"
+        | "eng"
+        | "chi"
+        | "kor"
+        | "fre"
+        | "ger"
+        | "rus"
+        | "spa"
+        | "ita"
+        | "por"
+      )[];
+    type?:
+      | "Book"
+      | "Article"
+      | "Journal"
+      | "Newspaper"
+      | "Thesis"
+      | "Map"
+      | "Music"
+      | "Video"
+      | "Sound"
+      | "Software"
+      | "Website"
+      | "Database";
+  };
+}> = z.object({
   /**
    * Title search
    */

--- a/src/schemas/sru/request.ts
+++ b/src/schemas/sru/request.ts
@@ -16,7 +16,8 @@ export const SRUOperationSchema = z.enum([
 /**
  * SRU version schema
  */
-export const SRUVersionSchema = z.enum(["1.1", "1.2"]).default("1.2");
+export const SRUVersionSchema: z.ZodType<"1.1" | "1.2"> = z.enum(["1.1", "1.2"])
+  .default("1.2");
 
 /**
  * CQL query schema
@@ -28,7 +29,15 @@ export const CQLQuerySchema = z.string().min(1, "CQL query cannot be empty");
  * SRU record schema identifiers
  * Common schemas supported by NDL
  */
-export const SRURecordSchemaSchema = z.enum([
+export const SRURecordSchemaSchema: z.ZodType<
+  | "info:srw/schema/1/dc-v1.1"
+  | "info:srw/schema/1/mods-v3.0"
+  | "http://www.loc.gov/mods/v3"
+  | "info:srw/schema/1/marcxml-v1.1"
+  | "http://www.loc.gov/MARC21/slim"
+  | "dcndl"
+  | "dcterms"
+> = z.enum([
   "info:srw/schema/1/dc-v1.1",
   "info:srw/schema/1/mods-v3.0",
   "http://www.loc.gov/mods/v3",

--- a/src/utils/cql-builder.ts
+++ b/src/utils/cql-builder.ts
@@ -20,6 +20,7 @@ import type {
 import {
   AdvancedSearchParamsSchema,
   CQLBuilderOptionsSchema,
+  DateRangeSchema,
   QueryValidationResultSchema,
   SimpleSearchParamsSchema,
 } from "../schemas/sru/query-builder.ts";
@@ -134,8 +135,8 @@ export class CQLQueryBuilder {
    */
   dateRange(range: DateRange): this {
     const validationResult = safeParse(
-      SimpleSearchParamsSchema.pick({ dateRange: true }),
-      { dateRange: range },
+      DateRangeSchema,
+      range,
     );
 
     if (validationResult.isErr()) {


### PR DESCRIPTION
## Summary

JSRのslow types検証で検出された9個のZodスキーマに明示的型注釈を追加し、JSR publishが成功するよう修正しました。

## 修正内容

### 型注釈を追加したスキーマ (9個)

1. **src/schemas/common.ts**
   - `MaximumRecordsSchema`: `z.ZodDefault<z.ZodNumber>`型注釈

2. **src/schemas/opensearch/request.ts**  
   - `OpenSearchQuerySchema`: `z.ZodString`型注釈
   - `OpenSearchRequestSchema`: `z.ZodType<T>`型注釈

3. **src/schemas/sru/query-builder.ts**
   - `NDLLanguageCodeSchema`: `z.ZodType<union>`型注釈
   - `NDLMaterialTypeSchema`: `z.ZodType<union>`型注釈  
   - `DateRangeSchema`: `z.ZodType<T>`型注釈
   - `SimpleSearchParamsSchema`: `z.ZodType<T>`型注釈

4. **src/schemas/sru/request.ts**
   - `SRUVersionSchema`: `z.ZodType<union>`型注釈
   - `SRURecordSchemaSchema`: `z.ZodType<union>`型注釈

### 付随修正

- `src/utils/cql-builder.ts`: `DateRangeSchema`のimport追加と利用方法の修正

## Test plan

- [x] TypeScript型チェック通過
- [x] 全テスト通過 (76/76)
- [x] リント・フォーマットチェック通過
- [x] Denoタスク `deno task check` 通過

## 期待される効果

JSR publishワークフローで発生していたslow typesエラーが解消され、パッケージの正常な公開が可能になります。

🤖 Generated with [Claude Code](https://claude.ai/code)