### PR TITLE
fix: JSR公開エラーを修正 - Thumbnailスキーマの明示的型アノテーション追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - JSR公開エラーを修正 - Thumbnailスキーマの明示的型アノテーション追加
-- ThumbnailRequestSchema, ThumbnailMetadataSchema, ThumbnailResponseSchema, ThumbnailExistsResponseSchemaに明示的型アノテーション追加
+- ThumbnailRequestSchema, ThumbnailMetadataSchema, ThumbnailResponseSchema,
+  ThumbnailExistsResponseSchemaに明示的型アノテーション追加
 - 不要なImageFormatSchemaを削除し直接文字列リテラル型に変更
 
 ## [0.1.202506150741] - 2025-06-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **MINOR番号**: 新機能追加時に手動でインクリメント
 - **MAJOR番号**: 現在のプロジェクトフェーズでは使用しない
 
+## [0.1.202506150757] - 2025-06-15
+
+### Fixed
+
+- JSR公開エラーを修正 - Thumbnailスキーマの明示的型アノテーション追加
+- ThumbnailRequestSchema, ThumbnailMetadataSchema, ThumbnailResponseSchema, ThumbnailExistsResponseSchemaに明示的型アノテーション追加
+- 不要なImageFormatSchemaを削除し直接文字列リテラル型に変更
+
 ## [0.1.202506150741] - 2025-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const result = await fetchThumbnail({ id: "9784422311074" });
 if (result.isOk()) {
   const thumbnail = result.value;
   console.log(`取得: ${thumbnail.id}, サイズ: ${thumbnail.metadata.size}`);
-  
+
   // ファイルに保存
   await saveThumbnailToFile(thumbnail, "thumbnail.jpg");
 } else {

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ deno add jsr:@masinc/ndl
 ```json
 {
   "imports": {
-    "@masinc/ndl": "jsr:@masinc/ndl@^0.1.202506150741"
+    "@masinc/ndl": "jsr:@masinc/ndl@^0.1.202506150757"
   }
 }
 ```

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@masinc/ndl",
-  "version": "0.1.202506150741",
+  "version": "0.1.202506150757",
   "exports": {
     ".": "./mod.ts",
     "./cli": "./cli.ts"

--- a/src/schemas/thumbnail/mod.ts
+++ b/src/schemas/thumbnail/mod.ts
@@ -14,8 +14,6 @@ export {
 
 // Response schemas
 export {
-  type ImageFormat,
-  ImageFormatSchema,
   type ThumbnailExistsResponse,
   ThumbnailExistsResponseSchema,
   type ThumbnailMetadata,

--- a/src/schemas/thumbnail/request.ts
+++ b/src/schemas/thumbnail/request.ts
@@ -9,7 +9,9 @@ import { z } from "zod";
 /**
  * サムネイル取得リクエストパラメータ
  */
-export const ThumbnailRequestSchema = z.object({
+export const ThumbnailRequestSchema: z.ZodType<{
+  id: string;
+}> = z.object({
   /**
    * 識別子（ISBN等）
    */
@@ -21,6 +23,8 @@ export type ThumbnailRequest = z.infer<typeof ThumbnailRequestSchema>;
 /**
  * サムネイル存在確認リクエストパラメータ
  */
-export const ThumbnailExistsRequestSchema = ThumbnailRequestSchema;
+export const ThumbnailExistsRequestSchema: z.ZodType<{
+  id: string;
+}> = ThumbnailRequestSchema;
 
 export type ThumbnailExistsRequest = ThumbnailRequest;

--- a/src/schemas/thumbnail/response.ts
+++ b/src/schemas/thumbnail/response.ts
@@ -7,20 +7,16 @@
 import { z } from "zod";
 
 /**
- * 画像形式
- */
-export const ImageFormatSchema = z.enum([
-  "image/jpeg",
-  "image/png",
-  "image/gif",
-  "image/webp",
-]);
-export type ImageFormat = z.infer<typeof ImageFormatSchema>;
-
-/**
  * サムネイル画像メタデータ
  */
-export const ThumbnailMetadataSchema = z.object({
+export const ThumbnailMetadataSchema: z.ZodType<{
+  size: string;
+  format: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+  fileSize: number;
+  width: number;
+  height: number;
+  lastModified?: string;
+}> = z.object({
   /**
    * 画像サイズ
    */
@@ -29,7 +25,7 @@ export const ThumbnailMetadataSchema = z.object({
   /**
    * 画像形式
    */
-  format: ImageFormatSchema,
+  format: z.enum(["image/jpeg", "image/png", "image/gif", "image/webp"]),
 
   /**
    * ファイルサイズ（バイト）
@@ -57,7 +53,12 @@ export type ThumbnailMetadata = z.infer<typeof ThumbnailMetadataSchema>;
 /**
  * サムネイル取得成功レスポンス
  */
-export const ThumbnailResponseSchema = z.object({
+export const ThumbnailResponseSchema: z.ZodType<{
+  id: string;
+  imageData: Uint8Array;
+  metadata: ThumbnailMetadata;
+  imageUrl: string;
+}> = z.object({
   /**
    * 識別子
    */
@@ -84,7 +85,11 @@ export type ThumbnailResponse = z.infer<typeof ThumbnailResponseSchema>;
 /**
  * サムネイル存在確認レスポンス
  */
-export const ThumbnailExistsResponseSchema = z.object({
+export const ThumbnailExistsResponseSchema: z.ZodType<{
+  id: string;
+  exists: boolean;
+  checkedAt: string;
+}> = z.object({
   /**
    * 識別子
    */


### PR DESCRIPTION
## 修正内容

JSR公開失敗の原因となっていたZodスキーマの明示的型アノテーション不足を修正しました。

### 変更点

- **ThumbnailRequestSchema**: z.ZodType<{ id: string; }> アノテーション追加
- **ThumbnailMetadataSchema**: 明示的型アノテーション追加
- **ThumbnailResponseSchema**: 明示的型アノテーション追加
- **ThumbnailExistsResponseSchema**: 明示的型アノテーション追加
- **ImageFormatSchema削除**: 直接文字列リテラル型に変更

### 修正前のエラー

```
error[missing-explicit-type]: missing explicit type in the public API
```

以下のファイルで発生していました:
- src/schemas/thumbnail/request.ts:12:14
- src/schemas/thumbnail/response.ts で複数箇所

### テスト結果

- ✅ 型チェック通過
- ✅ リント通過  
- ✅ フォーマットチェック通過
- ✅ 全ユニットテスト通過

## Closes

Closes #25